### PR TITLE
Added support for dc:creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ preprocessors:
 ```
 
 In the resulting HTML files the `foo` and `dc:creator` information would be
-stored under `custom_foo_field_name` and `creator` keys. 
+stored under `custom_foo_field_name` and `creator` keys.
+
+These custom field names can be used to alias or override default field names
+and map a value to multiple aliases.  
 
 ### Importing feed
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,30 @@ preprocessors:
   - feed
 ```
 
+### Custom fields
+
+If custom fields are necessary they can be specified as part of the preprocessor
+config. For instance if you wanted to add a creator field `<dc:creator>` and a
+`<foo>` field with custom names, you would update the previous example as
+follows:
+
+```
+preprocessors:
+- name: my_feed
+  kind: xml_feed
+  autorun: false
+  url: https://www.blog.google/rss/
+  collection: /content/feed/
+  custom_field_names:
+    creator: '{http://purl.org/dc/elements/1.1/}creator'
+    custom_foo_field_name: 'foo'
+  tags:
+  - feed
+```
+
+In the resulting HTML files the `foo` and `dc:creator` information would be
+stored under `custom_foo_field_name` and `creator` keys. 
+
 ### Importing feed
 
 To run the feed import run `grow preprocess -p my_feed`.

--- a/xml_feed/xml_feed.py
+++ b/xml_feed/xml_feed.py
@@ -157,7 +157,9 @@ class XmlFeedPreprocessHook(hooks.PreprocessHook):
 
         raw_feed = self._download_feed(config_message.url)
         for article in self._parse_articles(raw_feed, options):
-            pod_path = '{}{}.html'.format(config_message.collection, article.slug)
+            safe_article_slug = article.slug.replace('.', '-dot')
+            pod_path = '{}{}.html'.format(
+                config_message.collection, safe_article_slug)
             data = collections.OrderedDict()
 
             data['$title'] = article.title

--- a/xml_feed/xml_feed.py
+++ b/xml_feed/xml_feed.py
@@ -1,6 +1,7 @@
 """Xml feed extension for importing xml feeds into Grow documents."""
 
 import collections
+import re
 import requests
 import textwrap
 import yaml
@@ -157,9 +158,11 @@ class XmlFeedPreprocessHook(hooks.PreprocessHook):
 
         raw_feed = self._download_feed(config_message.url)
         for article in self._parse_articles(raw_feed, options):
-            safe_article_slug = article.slug.replace('.', '-dot')
+            removed_duplicate_dots = re.sub(r'([\.]{2,})', '.', article.slug)
+            removed_trailing_dot = re.sub(
+                r'([\.]$)', '', removed_duplicate_dots)
             pod_path = '{}{}.html'.format(
-                config_message.collection, safe_article_slug)
+                config_message.collection, removed_trailing_dot)
             data = collections.OrderedDict()
 
             data['$title'] = article.title

--- a/xml_feed/xml_feed.py
+++ b/xml_feed/xml_feed.py
@@ -17,6 +17,7 @@ from grow.extensions import hooks
 
 CONTENT_KEYS = structures.AttributeDict({
     'title': 'title',
+    'creator': '{http://purl.org/dc/elements/1.1/}creator',
     'description': 'description',
     'link': 'link',
     'published': 'pubDate',
@@ -28,6 +29,7 @@ class Article(object):
 
     def __init__(self):
         self.title = None
+        self.creator = None
         self.description = None
         self.image = None
         self.link = None
@@ -69,6 +71,8 @@ class XmlFeedPreprocessHook(hooks.PreprocessHook):
             for child in item:
                 if child.tag == CONTENT_KEYS.title:
                     article.title = child.text.encode('utf8')
+                elif child.tag == CONTENT_KEYS.creator:
+                    article.creator = child.text.encode('utf8')
                 elif child.tag == CONTENT_KEYS.description:
                     article.description = child.text.encode('utf8')
                     article.content = child.text.encode('utf8')
@@ -118,6 +122,7 @@ class XmlFeedPreprocessHook(hooks.PreprocessHook):
             data = collections.OrderedDict()
             data['$title'] = article.title
             data['$description'] = article.description
+            data['creator'] = article.creator
             data['image'] = article.image
             data['published'] = article.published
             data['link'] = article.link

--- a/xml_feed/xml_feed.py
+++ b/xml_feed/xml_feed.py
@@ -158,9 +158,8 @@ class XmlFeedPreprocessHook(hooks.PreprocessHook):
 
         raw_feed = self._download_feed(config_message.url)
         for article in self._parse_articles(raw_feed, options):
-            removed_duplicate_dots = re.sub(r'([\.]{2,})', '.', article.slug)
-            removed_trailing_dot = re.sub(
-                r'([\.]$)', '', removed_duplicate_dots)
+            removed_duplicate_dots = re.sub(r'[\.]{2,}', '.', article.slug)
+            removed_trailing_dot = re.sub(r'[\.]$', '', removed_duplicate_dots)
             pod_path = '{}{}.html'.format(
                 config_message.collection, removed_trailing_dot)
             data = collections.OrderedDict()


### PR DESCRIPTION
Adds field aliases to pull additional data from feeds and store it under custom keys.
Replace "."s in filenames with "-dot" so article's white "." in their slug can be saved.