### PR TITLE
Remove spaces remaining after slugify

### DIFF
--- a/xml_feed/xml_feed.py
+++ b/xml_feed/xml_feed.py
@@ -160,8 +160,9 @@ class XmlFeedPreprocessHook(hooks.PreprocessHook):
         for article in self._parse_articles(raw_feed, options):
             removed_duplicate_dots = re.sub(r'[\.]{2,}', '.', article.slug)
             removed_trailing_dot = re.sub(r'[\.]$', '', removed_duplicate_dots)
+            removed_spaces = re.sub(r'[\s]', '', removed_trailing_dot)
             pod_path = '{}{}.html'.format(
-                config_message.collection, removed_trailing_dot)
+                config_message.collection, removed_spaces)
             data = collections.OrderedDict()
 
             data['$title'] = article.title


### PR DESCRIPTION
Error seen when trying to parse the emdash in a title like https://medium.com/wing-aviation/introducing-opensky-a-platform-to-empower-everyone-to-safely-access-the-sky-e54ed69bf70c